### PR TITLE
Added `grouped_matcher` feature and allow skipping from impls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,9 @@ dtype_variant = { path = "dtype_variant", version = "0.0.6" }
 dtype_variant_derive = { path = "dtype_variant_derive", version = "0.0.6" }
 
 darling = "0.20.11"
+indexmap = "2.9.0"
+paste = "1.0.15"
 proc-macro-crate = "3.3.0"
 proc-macro2 = "1.0.94"
 quote = "1.0.40"
 syn = "2.0.100"
-paste = "1.0.15"

--- a/dtype_variant/src/lib.rs
+++ b/dtype_variant/src/lib.rs
@@ -29,7 +29,11 @@ mod tests {
     build_dtype_tokens!([U16, U32, U64]);
 
     #[derive(Clone, Debug, Default, DType)]
-    #[dtype(matcher = "match_my_enum_variant", tokens = "self", constraint = "Constraint")]
+    #[dtype(
+        matcher = "match_my_enum_variant",
+        tokens = "self",
+        constraint = "Constraint"
+    )]
     pub enum MyEnumVariant {
         U16,
         U32,
@@ -137,5 +141,38 @@ mod tests {
             let str_repr = value.to_string();
             assert_eq!(str_repr, "3.14");
         });
+    }
+
+    build_dtype_tokens!([A, B, C, D]);
+
+    #[derive(DType)]
+    #[dtype(
+        tokens = "self",
+        grouped_matcher = "match_my_enum_grouped, {
+            Numeric: [A, B],
+            UnitLike: [C, D]
+        }"
+    )]
+    enum MyEnum2 {
+        A(u32),
+        B(u64),
+        C,
+        D,
+    }
+
+    #[test]
+    fn test_match_grouped() {
+        let val = MyEnum2::A(42);
+
+        let str = match_my_enum_grouped!(val,
+            Numeric:MyEnum2<T, Variant>(inner) => {
+                format!("Integer variant: {}", inner)
+            },
+            UnitLike:MyEnum2<Variant> => {
+                "C, D variant".to_string()
+            },
+        );
+
+        assert_eq!(str, "Integer variant: 42");
     }
 }

--- a/dtype_variant/src/lib.rs
+++ b/dtype_variant/src/lib.rs
@@ -151,8 +151,10 @@ mod tests {
         grouped_matcher = "match_my_enum_grouped, {
             Numeric: [A, B],
             UnitLike: [C, D]
-        }"
+        }",
+        skip_from_impls = true
     )]
+    #[allow(dead_code)]
     enum MyEnum2 {
         A(u32),
         B(u64),

--- a/dtype_variant_derive/Cargo.toml
+++ b/dtype_variant_derive/Cargo.toml
@@ -13,6 +13,7 @@ proc-macro = true
 
 [dependencies]
 darling.workspace = true
+indexmap.workspace = true
 proc-macro-crate.workspace = true
 proc-macro2.workspace = true
 quote.workspace = true

--- a/dtype_variant_derive/src/derive.rs
+++ b/dtype_variant_derive/src/derive.rs
@@ -791,6 +791,7 @@ fn generate_from_impls(
     if skip_from_impls {
         quote! {
             #from_variant_impl
+            #(#unit_from_impls)*
         }
     } else {
         quote! {

--- a/dtype_variant_derive/src/lib.rs
+++ b/dtype_variant_derive/src/lib.rs
@@ -3,12 +3,16 @@ use quote::{format_ident, quote};
 use syn::{Ident, Token, parse_macro_input, punctuated::Punctuated};
 
 mod derive;
+mod matcher_gen;
 
 pub(crate) fn dtype_variant_path() -> syn::Path {
-    let found_crate = proc_macro_crate::crate_name("dtype_variant").expect("dtype_variant is present in `Cargo.toml`");
+    let found_crate = proc_macro_crate::crate_name("dtype_variant")
+        .expect("dtype_variant is present in `Cargo.toml`");
     match found_crate {
         proc_macro_crate::FoundCrate::Itself => format_ident!("crate").into(),
-        proc_macro_crate::FoundCrate::Name(name) => syn::parse(name.parse().unwrap()).unwrap(),
+        proc_macro_crate::FoundCrate::Name(name) => {
+            syn::parse(name.parse().unwrap()).unwrap()
+        }
     }
 }
 

--- a/dtype_variant_derive/src/matcher_gen.rs
+++ b/dtype_variant_derive/src/matcher_gen.rs
@@ -1,0 +1,304 @@
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+use syn::Ident;
+
+use crate::derive::ParsedVariantInfo;
+
+pub struct MatchArmParam {
+    pub enum_name: Ident, // Needed for context if type paths are relative? Maybe not.
+    // --- Flags ---
+    pub all_unit_variants: bool, // Optimization for simpler type declarations
+    pub include_inner: bool,     // Should $src_type be defined?
+    pub src_type_generic: bool,  // Is $src_type generic?
+    pub include_dest: bool,      // Should $dest_type be defined?
+    pub dest_type_generic: bool, // Is $dest_type generic?
+    pub dest_constraint: bool,   // Should $dest_constraint be defined?
+    pub dest_constraint_generic: bool, // Is $dest_constraint generic?
+    // --- Identifiers used in the macro pattern ---
+    pub inner_ident: TokenStream2, // The ident captured for the inner value (e.g., `inner`, `payload`)
+    pub token_type_ident: TokenStream2, // The ident captured for the token type (e.g., `Token`, `TType`)
+    pub src_type_ident: TokenStream2, // The ident captured for the src type (e.g., `Src`)
+    pub src_type_generic_ident: TokenStream2, // The ident captured for src type generic (e.g., `G`)
+    pub dest_enum_ident: TokenStream2, // The ident captured for the dest enum (e.g., `DestEnum`)
+    pub dest_type_ident: TokenStream2, // The ident captured for the dest type (e.g., `Dest`)
+    pub dest_type_generic_ident: TokenStream2, // The ident captured for dest type generic (e.g., `DG`)
+    pub dest_constraint_ident: TokenStream2, // The ident captured for dest constraint (e.g., `Constraint`)
+    pub dest_constraint_generic_ident: TokenStream2, // The ident captured for dest constraint generic (e.g., `CG`)
+
+    // --- Path Generation ---
+    pub token_path: TokenStream2, // Closure to get `crate::tokens`
+    pub dtype_variant_path: TokenStream2, // Closure to get `crate::dtype_variant_path`
+    // --- Final User Code ---
+    pub user_body_code: TokenStream2, // The actual code block provided by the user (`$body`)
+}
+
+/// **NEW**: Generates the code block `{ ... }` for a single match arm.
+/// This includes type declarations, inner binding logic (if applicable), and the final user code.
+pub fn generate_match_arm_content(
+    variant_info: &ParsedVariantInfo,
+    param: &MatchArmParam,
+) -> TokenStream2 {
+    let MatchArmParam {
+        all_unit_variants,
+        include_inner,
+        src_type_generic,
+        include_dest,
+        dest_type_generic,
+        dest_constraint,
+        dest_constraint_generic,
+        inner_ident,
+        token_type_ident,
+        src_type_ident,
+        src_type_generic_ident,
+        dest_enum_ident,
+        dest_type_ident,
+        dest_type_generic_ident,
+        dest_constraint_ident,
+        dest_constraint_generic_ident,
+        token_path,
+        dtype_variant_path,
+        user_body_code,
+        ..
+    } = param;
+    let token_ident = &variant_info.token_ident;
+    let inner_type = variant_info
+        .inner_type
+        .as_ref()
+        .map(|ty| quote! { #ty })
+        .unwrap_or(quote! { () });
+
+    let token_type_path = quote!(#token_path :: #token_ident);
+
+    // --- Type Declarations ---
+    let type_declarations = if *all_unit_variants {
+        quote! {
+            #[allow(unused)] type #token_type_ident = #token_type_path;
+        }
+    } else {
+        let src_generic = src_type_generic
+            .then_some(quote! { < #src_type_generic_ident > })
+            .unwrap_or_default();
+        let inner_decl = include_inner
+            .then_some(quote! {
+                #[allow(unused)] type #src_type_ident #src_generic = #inner_type;
+            })
+            .unwrap_or_default();
+
+        quote! {
+            #inner_decl
+            #[allow(unused)] type #token_type_ident = #token_type_path;
+        }
+    };
+
+    // --- Dest Type/Constraint Declarations ---
+    let dest_generic = dest_type_generic
+        .then_some(quote! { < #dest_type_generic_ident > })
+        .unwrap_or_default();
+    let dest_constr_generic = dest_constraint_generic
+        .then_some(quote! { < #dest_constraint_generic_ident > })
+        .unwrap_or_default(); // Separate generic possible
+
+    let dest_type_decl = include_dest
+        .then_some(quote! {
+            #[allow(unused)]
+             type #dest_type_ident #dest_generic = <#dest_enum_ident #dest_generic as #dtype_variant_path::EnumVariantDowncast<#token_type_path>>::Target;
+        })
+        .unwrap_or_default();
+
+    let dest_constraint_decl = dest_constraint
+        .then_some(quote! {
+            #[allow(unused)]
+             type #dest_constraint_ident #dest_constr_generic = <#dest_enum_ident #dest_constr_generic as #dtype_variant_path::EnumVariantConstraint<#token_type_path>>::Constraint;
+        })
+        .unwrap_or_default();
+
+    // --- Inner Binding Logic (for unit variants when inner is requested) ---
+    // Note: The actual binding `Variant(inner_ident)` happens in the *pattern*.
+    // This only handles the case where the pattern expects `inner_ident`, but the variant is Unit.
+    let inner_unit_binding = match (include_inner, variant_info.is_unit) {
+        (true, true) => (!all_unit_variants)
+            .then_some(quote! {
+               #[allow(unused_variables, clippy::let_unit_value)]
+               let #inner_ident = (); // Provide a unit binding for consistency if inner requested
+            })
+            .unwrap_or_default(),
+        _ => quote! {},
+    };
+
+    // --- Combine into the final arm body ---
+    quote! {
+        { // Wrap in braces
+            #inner_unit_binding
+            #type_declarations
+            #dest_type_decl
+            #dest_constraint_decl
+
+            #[allow(unused_braces)] // Allow {$body} even if it's just {}
+            #user_body_code // <<< Execute the final user code
+        }
+    }
+}
+
+// --- Generate Macro Arms ---
+// Helper *inside* generate_matcher_method to generate the Vec<TokenStream2> of match arms
+// MyEnum2::A($inner) => {
+//     #[allow(unused)]type$SrcTy = u32;
+//     #[allow(unused)]type$TokenTy =  $crate::tokens::AVariant;
+//     #[allow(unused)]type$DestTy =  < $DestEnum as dtype_variant::EnumVariantDowncast< $crate::tokens::AVariant>> ::Target;
+//     #[allow(unused)]type$ConstraintTy =  < $DestEnum as dtype_variant::EnumVariantConstraint< $crate::tokens::AVariant>> ::Constraint;
+//     #[allow(unused_braces)]$body
+pub fn generate_match_arms_for_regular_matcher(
+    param: &MatchArmParam,
+    parsed_variants: &[ParsedVariantInfo],
+) -> Vec<TokenStream2> {
+    parsed_variants
+        .iter()
+        .map(|v| {
+            let MatchArmParam {
+                enum_name,
+                include_inner,
+                inner_ident,
+                ..
+            } = param;
+            let variant_ident = &v.variant_ident;
+
+            // 1. Generate the pattern
+            let pattern = match (include_inner, v.is_unit) {
+                (_, true) => quote! { #enum_name::#variant_ident },
+                (false, false) => {
+                    quote! { #enum_name::#variant_ident(_) }
+                }
+                (true, false) => {
+                    quote! { #enum_name::#variant_ident(#inner_ident) }
+                } // Use captured inner_ident
+            };
+
+            // 2. Generate the arm body content using the new helper
+            let arm_body_content = generate_match_arm_content(v, param);
+
+            // 3. Combine pattern and body
+            quote! { #pattern => #arm_body_content }
+        })
+        .collect::<Vec<_>>() // Collect into Vec<TokenStream2>
+}
+
+pub struct MacroRuleArm {
+    pub pattern_prefix_fragment: TokenStream2,
+    pub pattern_suffix_fragment: TokenStream2,
+    pub variant_bodies: TokenStream2,
+}
+
+// Helper *inside* generate_matcher_method specific to the regular matcher's macro patterns
+//   ($value:expr, $enum_:ident< $SrcTy:ident, $TokenTy:ident>($inner:ident), $DestEnum:ident< $DestTy:ident, $ConstraintTy:ident>  =>  $body:block) => {
+// match$value {
+pub fn generate_macro_rule_arm(
+    enum_name: &Ident,
+    parsed_variants: &[ParsedVariantInfo],
+    tokens_path: TokenStream2,
+    dtype_variant_path: &TokenStream2,
+    bindname_suffix: Option<u8>,
+) -> impl Fn(bool, bool, bool, bool, bool) -> MacroRuleArm {
+    let all_unit_variants = parsed_variants.iter().all(|v| v.is_unit);
+
+    move |include_inner: bool,
+          src_type_generic: bool,
+          include_dest: bool,
+          dest_type_generic: bool,
+          dest_constraint: bool| {
+        // Define the idents used in this specific macro pattern with optional suffix
+        let suffix = bindname_suffix
+            .map(|n| format!("{}", n))
+            .unwrap_or_default();
+
+        let binding_ts = |name: &str| -> TokenStream2 {
+            syn::parse_str::<TokenStream2>(&format!("{}{}", name, suffix))
+                .unwrap()
+        };
+
+        let inner_ident = binding_ts("$inner");
+        let token_type_ident = binding_ts("$TokenTy"); // Choose consistent internal names
+        let src_type_ident = binding_ts("$SrcTy");
+        let src_type_generic_ident = binding_ts("$SrcGen");
+        let dest_enum_ident = binding_ts("$DestEnum");
+        let dest_type_ident = binding_ts("$DestTy");
+        let dest_type_generic_ident = binding_ts("$DestGen");
+        let dest_constraint_ident = binding_ts("$ConstraintTy");
+        let dest_constraint_generic_ident = binding_ts("$ConstraintGen");
+        let body_ident = binding_ts("$body");
+        let enum_ident = binding_ts("$enum_");
+
+        let param = MatchArmParam {
+            inner_ident: inner_ident.clone(),
+            token_type_ident: token_type_ident.clone(),
+            src_type_ident: src_type_ident.clone(),
+            src_type_generic_ident: src_type_generic_ident.clone(),
+            dest_enum_ident: dest_enum_ident.clone(),
+            dest_type_ident: dest_type_ident.clone(),
+            dest_type_generic_ident: dest_type_generic_ident.clone(),
+            dest_constraint_ident: dest_constraint_ident.clone(),
+            dest_constraint_generic_ident: dest_constraint_generic_ident
+                .clone(),
+            include_inner,
+            src_type_generic,
+            include_dest,
+            dest_constraint,
+            dest_type_generic,
+            user_body_code: body_ident.clone(),
+            enum_name: enum_name.clone(),
+            all_unit_variants,
+            dest_constraint_generic: dest_type_generic,
+            token_path: tokens_path.clone(),
+            dtype_variant_path: dtype_variant_path.clone(),
+        };
+
+        // Generate the list of match arms using the helper above
+        let match_arms =
+            generate_match_arms_for_regular_matcher(&param, parsed_variants);
+
+        // Define the outer macro rule pattern (same as before)
+        let source_enum_type = if include_inner {
+            let src_generic = src_type_generic
+                .then_some(quote!(<#src_type_generic_ident:tt>))
+                .unwrap_or_default();
+            quote! { #enum_ident:ident<#src_type_ident:ident #src_generic, #token_type_ident:ident> }
+        } else {
+            quote! { #enum_ident:ident<#token_type_ident:ident> }
+        };
+        let macro_arm_inner = include_inner
+            .then_some(quote! { (#inner_ident:ident) })
+            .unwrap_or_default(); // Use fixed inner_ident
+        let (dest_generic, dest_constr_generic) = match dest_type_generic {
+            true => (
+                quote!(<#dest_type_generic_ident:tt>),
+                quote!(<#dest_constraint_generic_ident:tt>),
+            ),
+            false => (quote!(), quote!()),
+        };
+        let dest_enum_type = match (include_dest, dest_constraint) {
+            (true, true) => {
+                quote! { , #dest_enum_ident:ident <#dest_type_ident:ident #dest_generic, #dest_constraint_ident:ident #dest_constr_generic > }
+            }
+            (true, false) => {
+                quote! { , #dest_enum_ident:ident <#dest_type_ident:ident #dest_generic> }
+            }
+            (false, true) => {
+                quote! { , #dest_enum_ident:ident <#dest_constraint_ident:ident #dest_constr_generic> }
+            }
+            (false, false) => quote!(),
+        };
+
+        let pattern_prefix_fragment = quote! { #source_enum_type };
+        let pattern_suffix_fragment =
+            quote! { #macro_arm_inner #dest_enum_type => #body_ident:block };
+
+        let variant_bodies = quote! {
+            #(#match_arms)* // Expand the generated match arms here
+        };
+
+        MacroRuleArm {
+            pattern_prefix_fragment,
+            pattern_suffix_fragment,
+            variant_bodies,
+        }
+    }
+}

--- a/examples/dynchunk/src/main.rs
+++ b/examples/dynchunk/src/main.rs
@@ -22,7 +22,12 @@ impl DPrimType {
 }
 
 #[derive(DType, Clone, Debug)]
-#[dtype(constraint = "DPrim", tokens = "self", container = "Vec", matcher = "match_enum")]
+#[dtype(
+    constraint = "DPrim",
+    tokens = "self",
+    container = "Vec",
+    matcher = "match_enum"
+)]
 enum DynChunk {
     I32(Vec<i32>),
     F32(Vec<f32>),
@@ -49,7 +54,11 @@ impl DynChunk {
 }
 
 #[derive(DType, Clone, Debug)]
-#[dtype(constraint = "DPrim", tokens = "self", matcher = "match_dyn_chunk_borrowed")]
+#[dtype(
+    constraint = "DPrim",
+    tokens = "self",
+    matcher = "match_dyn_chunk_borrowed"
+)]
 enum DynChunkBorrowed<'a> {
     I32(&'a Vec<i32>),
     F32(&'a Vec<f32>),

--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -2,14 +2,20 @@ use dtype_variant::*;
 use dtype_variant_example_shared::variants::AttackVariant;
 
 #[derive(Clone, Debug, DType)]
-#[dtype(matcher = "player_input_enum", tokens = "dtype_variant_example_shared::variants")]
+#[dtype(
+    matcher = "player_input_enum",
+    tokens = "dtype_variant_example_shared::variants"
+)]
 pub enum PlayerInput {
     Move(String),
     Attack(u32),
 }
 
 #[derive(Clone, Debug, DType)]
-#[dtype(matcher = "ai_behavior_enum", tokens = "dtype_variant_example_shared::variants")]
+#[dtype(
+    matcher = "ai_behavior_enum",
+    tokens = "dtype_variant_example_shared::variants"
+)]
 pub enum AIBehavior {
     Attack(u32),
     Flee(bool),
@@ -20,7 +26,10 @@ fn main() {
     let ai_attack = AIBehavior::from(30_u32); // Attack with power level 30
 
     // Process shared actions (e.g., Attack) between player and AI
-    let combined_attack = combine_shared_actions::<AttackVariant, u32>(&player_attack, &ai_attack);
+    let combined_attack = combine_shared_actions::<AttackVariant, u32>(
+        &player_attack,
+        &ai_attack,
+    );
     match combined_attack {
         Some(total_power) => println!("Combined attack power: {}", total_power),
         None => println!("Actions do not match."),
@@ -28,7 +37,10 @@ fn main() {
 }
 
 // Function to combine shared actions if their types match
-fn combine_shared_actions<Variant, Target>(action1: &PlayerInput, action2: &AIBehavior) -> Option<Target>
+fn combine_shared_actions<Variant, Target>(
+    action1: &PlayerInput,
+    action2: &AIBehavior,
+) -> Option<Target>
 where
     PlayerInput: EnumVariantDowncast<Variant, Target = Target>,
     AIBehavior: EnumVariantDowncast<Variant, Target = Target>,

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,6 +1,6 @@
 tab_spaces = 4
-max_width=120
-fn_call_width=64
+max_width = 80
+fn_call_width = 64
 
 reorder_imports = true
 


### PR DESCRIPTION
* Allow variants to be grouped in a new powerful macro.
* Skip from_impls for non unit variants

```rust
#[derive(DType)]
#[dtype(
    tokens = "self",
    grouped_matcher = "match_my_enum_grouped, {
        Numeric: [A, B],
        UnitLike: [C, D]
    }"
)]
enum MyEnum2 {
    A(u32),
    B(u64),
    C,
    D,
}

fn test_match_grouped() {
    let val = MyEnum2::A(42);

    let str = match_my_enum_grouped!(val,
        Numeric:MyEnum2<T, Variant>(inner) => {
            format!("Integer variant: {}", inner)
        },
        UnitLike:MyEnum2<Variant> => {
            "C, D variant".to_string()
        },
    );

    assert_eq!(str, "Integer variant: 42");
}
```